### PR TITLE
restrict creationix package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "stack": ">=0.0.3",
-    "creationix": ">=0.1.2",
+    "creationix": ">=0.1.2 <=0.3.1",
     "wheat": ">=0.2.0",
     "cluster": ">=0.6.4"
   },


### PR DESCRIPTION
After doing steps from readme

> Install the npmpackages: npm install
> Start the server: node server/server.js
> Enjoy your local blog clone at http://localhost:8080

i got the following error (as a result of `node server/server.js`)

``` js
module.js:340
    throw err;
          ^
Error: Cannot find module 'creationix'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:362:17)
    at require (module.js:378:17)
    at Object.<anonymous> (/mnt/data/home/oleg/work/repository/git-hub/howtonode.org/server/server.js:3:18)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:492:10)
```

seems like creationix 0.4.0 is broken, so i just installed previous version (0.3.1) and it works fine
