### PR TITLE
Updated hello-tcp.js due to API changes.

### DIFF
--- a/articles/hello-node/hello-tcp.js
+++ b/articles/hello-node/hello-tcp.js
@@ -1,14 +1,12 @@
 // Load the net module to create a tcp server.
 var net = require('net');
 
-// Setup a tcp server
+// Creates a new TCP server. The handler argument is automatically set as a listener for the 'connection' event
 var server = net.createServer(function (socket) {
   
   // Every time someone connects, tell them hello and then close the connection.
-  socket.addListener("connect", function () {
-    sys.puts("Connection from " + socket.remoteAddress);
-    socket.end("Hello World\n");
-  });
+  console.log("Connection from " + socket.remoteAddress);
+  socket.end("Hello World\n");
   
 });
 


### PR DESCRIPTION
The "connect" event is assigned to handler that is passed to the createServer method.

The previous example didn't work since apparently you cannot assign again handler for "connect" event.

Replace sys.put with console.log, otherwise I would have to require 'sys'. (In previous node version probably that object was set as global)
